### PR TITLE
chore: setup swagger documentation infrastructure (#9)

### DIFF
--- a/backend/node_modules/.package-lock.json
+++ b/backend/node_modules/.package-lock.json
@@ -363,6 +363,7 @@
       "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.8.tgz",
       "integrity": "sha512-AhZV8/EIreHFmBV5wAs0gzJUNq9JbbSXgJLQubCC0jtIo6prnI9MIRRxnU4MZX9RB9yXxF1V4R7jtLl/Wcj31g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/express": "*",
         "@types/serve-static": "*"
@@ -2367,6 +2368,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
       "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
       "dependencies": {
         "swagger-ui-dist": ">=5.0.0"
       },

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -382,6 +382,7 @@
       "resolved": "https://registry.npmjs.org/@types/swagger-ui-express/-/swagger-ui-express-4.1.8.tgz",
       "integrity": "sha512-AhZV8/EIreHFmBV5wAs0gzJUNq9JbbSXgJLQubCC0jtIo6prnI9MIRRxnU4MZX9RB9yXxF1V4R7jtLl/Wcj31g==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/express": "*",
         "@types/serve-static": "*"
@@ -2400,6 +2401,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-5.0.1.tgz",
       "integrity": "sha512-SrNU3RiBGTLLmFU8GIJdOdanJTl4TOmT27tt3bWWHppqYmAZ6IDuEuBvMU6nZq0zLEe6b/1rACXCgLZqO6ZfrA==",
+      "license": "MIT",
       "dependencies": {
         "swagger-ui-dist": ">=5.0.0"
       },

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -7,18 +7,19 @@ const app = express();
 
 app.use(express.json());
 
+// 1. Swagger primeiro (boa prática)
+app.use('/docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
+
+// 2. Rotas simples
 app.get('/', (req, res) => {
   res.send('API rodando hehehe');
 });
 
+// 3. Suas rotas importadas
+app.use(healthRoutes);
+
+// 4. Iniciar o servidor
 app.listen(3000, () => {
   console.log('Servidor rodando em http://localhost:3000');
+  console.log('Documentação disponível em http://localhost:3000/docs');
 });
-
-app.get('/health', (req, res) => {
-  res.status(200).json({ status: 'ok' });
-});
-
-app.use('/docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
-
-app.use(healthRoutes);

--- a/backend/src/swagger.ts
+++ b/backend/src/swagger.ts
@@ -1,4 +1,5 @@
 import swaggerJSDoc from 'swagger-jsdoc';
+import path from 'path'; // Adicione este import
 
 const options = {
   definition: {
@@ -9,7 +10,13 @@ const options = {
       description: 'Documentação da API',
     },
   },
-  apis: ['./src/routes/*.ts'],
+  // Usar path.join garante que funcione no Windows e no Linux/Docker
+  apis: [
+    path.join(__dirname, './index.ts'),
+    path.join(__dirname, './index.js'),
+    path.join(__dirname, './routes/*.ts'),
+    path.join(__dirname, './routes/*.js'),
+  ],
 };
 
 export const swaggerSpec = swaggerJSDoc(options);


### PR DESCRIPTION
O que foi feito?
Instalação e configuração do swagger-ui-express e swagger-jsdoc.

Criação do arquivo de configuração swagger.ts com suporte a caminhos absolutos para rodar no Docker.

Disponibilização do endpoint /docs para visualização da API.

Documentação inicial da rota de health.

Links Relacionados
Closes #9

Como testar?
Rodar docker-compose up --build.

Acessar http://localhost:3000/docs.