### PR TITLE
feat: organização das rotas de aluno

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -12,6 +12,7 @@ import authRoutes from './routes/auth.routes';
 import userRoutes from './routes/user.routes'; 
 import vagaRoutes from './routes/vaga.routes';
 import habilidadeRoutes from './routes/habilidade.routes';
+import alunoRoutes from './routes/aluno.routes';
 import { empresaRoutes } from './routes/empresa.routes';
 import candidaturaRoutes from './routes/candidatura.routes';
 
@@ -43,6 +44,7 @@ app.use('/auth', authRoutes);
 app.use('/users', userRoutes); 
 app.use('/vagas', vagaRoutes);
 app.use('/habilidades', habilidadeRoutes);
+app.use('/alunos', alunoRoutes);
 app.use(candidaturaRoutes);
 
 const startServer = async () => {

--- a/backend/src/routes/candidatura.routes.ts
+++ b/backend/src/routes/candidatura.routes.ts
@@ -1,7 +1,6 @@
 import { Router } from "express";
 import { authMiddleware } from "../middlewares/authMiddleware";
 import { CandidaturaController } from "../controllers/CandidaturaController";
-import { AlunoController } from "../controllers/AlunoController";
 import { uploadConfig } from "../config/multer"; // NOVO: Importa o multer configurado
 
 const router = Router();
@@ -29,18 +28,6 @@ router.patch(
   "/candidaturas/:id/status",
   authMiddleware,
   CandidaturaController.atualizarStatus
-);
-
-router.get(
-  "/alunos/me",
-  authMiddleware,
-  AlunoController.meuPerfil
-);
-
-router.put(
-  "/alunos/me/habilidades",
-  authMiddleware,
-  AlunoController.atualizarHabilidades
 );
 
 export default router;


### PR DESCRIPTION
## O que foi feito

Organizei as rotas relacionadas ao aluno, registrando `alunoRoutes` no `index.ts` e removendo o workaround temporário que mantinha rotas de perfil/habilidades do aluno dentro de `candidatura.routes.ts`.

## Rotas de aluno organizadas

Agora ficam registradas corretamente em:

```ts
app.use('/alunos', alunoRoutes);