### PR TITLE
feat: calcula match real com habilidades

### DIFF
--- a/frontend/lib/pages/company_dashboard_page.dart
+++ b/frontend/lib/pages/company_dashboard_page.dart
@@ -584,6 +584,24 @@ class _CompanyDashboardPageState extends State<CompanyDashboardPage> {
         }
     }
 
+    double? matchPercent(dynamic item) {
+        final value = item['match_percent'] ?? item['pontuacao_compatibilidade'];
+
+        if (value is num) return value.toDouble();
+        if (value is String) return double.tryParse(value);
+
+        return null;
+    }
+
+    Widget chipMatch(double? match) {
+        if (match == null) return const SizedBox.shrink();
+
+        return Chip(
+            avatar: const Icon(Icons.insights, size: 18),
+            label: Text('${match.round()}% match'),
+        );
+    }
+
     Future<bool> atualizarStatusCandidatura({
         required int candidaturaId,
         required String novoStatus,
@@ -667,6 +685,7 @@ class _CompanyDashboardPageState extends State<CompanyDashboardPage> {
                             final curso = aluno?['curso'] ?? 'Curso não informado';
                             final statusAtual =
                                 candidatura['status']?.toString() ?? 'PENDENTE';
+                            final match = matchPercent(candidatura);
 
                             return ListTile(
                             leading: CircleAvatar(
@@ -689,6 +708,7 @@ class _CompanyDashboardPageState extends State<CompanyDashboardPage> {
                                         labelStatusCandidatura(statusAtual),
                                     ),
                                     ),
+                                    chipMatch(match),
                                 ],
                                 ),
                             ),

--- a/frontend/lib/pages/student_jobs_page.dart
+++ b/frontend/lib/pages/student_jobs_page.dart
@@ -179,6 +179,11 @@ class _StudentJobsPageState extends State<StudentJobsPage> {
           minhasHabilidadesIds = habilidadeIds;
         });
 
+        await carregarVagas();
+        if (mounted) {
+          setState(() {});
+        }
+
         ScaffoldMessenger.of(context).showSnackBar(
           const SnackBar(
             content: Text('Habilidades updated com sucesso.'),
@@ -433,6 +438,24 @@ class _StudentJobsPageState extends State<StudentJobsPage> {
     }
   }
 
+  double? matchPercent(dynamic item) {
+    final value = item['match_percent'] ?? item['pontuacao_compatibilidade'];
+
+    if (value is num) return value.toDouble();
+    if (value is String) return double.tryParse(value);
+
+    return null;
+  }
+
+  Widget chipMatch(double? match) {
+    if (match == null) return const SizedBox.shrink();
+
+    return Chip(
+      avatar: const Icon(Icons.insights, size: 18),
+      label: Text('${match.round()}% match'),
+    );
+  }
+
   List<dynamic> habilidadesDaVaga(dynamic vaga) {
     final relacoes = vaga['vagaHabilidades'];
 
@@ -509,6 +532,7 @@ class _StudentJobsPageState extends State<StudentJobsPage> {
 
     final bool jaCandidatou = statusCandidatura != null;
     final habilidades = habilidadesDaVaga(vaga);
+    final match = matchPercent(vaga);
 
     return Card(
       margin: const EdgeInsets.only(bottom: 12),
@@ -539,6 +563,7 @@ class _StudentJobsPageState extends State<StudentJobsPage> {
                   label: Text(vaga['modalidade'] ?? '-'),
                   avatar: const Icon(Icons.work_outline, size: 18),
                 ),
+                chipMatch(match),
               ],
             ),
             const SizedBox(height: 12),


### PR DESCRIPTION
## O que foi feito

Finalizei o cálculo e a exibição do match real entre aluno e vaga usando as habilidades cadastradas no banco.

O sistema agora considera as habilidades do aluno e as habilidades exigidas pela vaga para calcular o percentual de compatibilidade, sem usar valores mockados.

## Alterações principais

- Ajuste no serviço de match para retornar `0` quando aluno ou vaga não possuem habilidades
- Cálculo de match real ao candidatar aluno em uma vaga
- Recalculo do match ao listar candidaturas do aluno
- Recalculo do match ao listar candidatos de uma vaga para a empresa
- Exibição do match real na tela de vagas do aluno
- Exibição do match real na lista de candidatos da empresa
- Recarregamento das vagas após o aluno alterar suas habilidades

## Arquivos alterados

- `backend/src/services/matchService.ts`
- `backend/src/controllers/CandidaturaController.ts`
- `frontend/lib/pages/student_jobs_page.dart`
- `frontend/lib/pages/company_dashboard_page.dart`

## Validações realizadas

- [x] `cd backend && npm run build`
- [x] Backend subiu via Docker
- [x] Login do aluno de seed funcionando
- [x] Login da empresa de seed funcionando
- [x] `GET /vagas` como aluno retorna `match_percent`
- [x] `GET /vagas` como aluno retorna `skills_required`
- [x] `GET /vagas` como aluno retorna `skills_matched`
- [x] `GET /alunos/me/candidaturas` retorna `match_percent`
- [x] `GET /alunos/me/candidaturas` retorna `pontuacao_compatibilidade` atualizada
- [x] `GET /vagas/:id/candidaturas` retorna `match_percent`
- [x] `GET /vagas/:id/candidaturas` retorna `pontuacao_compatibilidade` coerente

## Evidência dos testes

- A vaga `8` retornou `match_percent: 28`, `skills_required: 5` e `skills_matched: 2` em `GET /vagas`
- A candidatura do aluno para a vaga `8` retornou `match_percent: 28` e `pontuacao_compatibilidade: 28`
- A listagem de candidatos da empresa para a vaga `8` também retornou `match_percent: 28` e `pontuacao_compatibilidade: 28`

## Observação

Não foram alterados seed, entidades, Docker, autenticação, Swagger ou telas de login/cadastro.

Closes #108 